### PR TITLE
Prepare for Midnight mainnet launch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ export circuit proveAgeOver(
 
 ### Prerequisites
 
-1. **Node.js 20+** and **pnpm**
+1. **Node.js 22+** and **pnpm**
 2. **Docker** and **Docker Compose** (for local Midnight network)
 3. **Compact Compiler** (Midnight's contract language)
 
@@ -91,13 +91,13 @@ export circuit proveAgeOver(
 curl -fsSL https://docs.midnight.network/install | bash
 
 # Install a specific version (must match pragma in .compact files)
-compact update 0.26.0
+compact update 0.28.0
 
 # Verify installation
-~/.compact/versions/0.26.0/x86_64-unknown-linux-musl/compactc.bin --version
+~/.compact/versions/0.28.0/x86_64-unknown-linux-musl/compactc.bin --version
 ```
 
-The Makefile expects `compactc.bin` to be in `~/.compact/versions/0.26.0/x86_64-unknown-linux-musl/`.
+The Makefile expects `compactc.bin` to be in `~/.compact/versions/0.28.0/x86_64-unknown-linux-musl/`.
 
 ### Makefile Commands
 
@@ -138,7 +138,7 @@ make status
 # Or manually:
 curl http://localhost:9944/health      # Node
 curl http://localhost:6300/health      # Proof server
-curl http://localhost:8088/api/v1/graphql  # Indexer
+curl http://localhost:8088/api/v3/graphql  # Indexer
 ```
 
 ## Related Packages

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
       start_period: 40s
 
   # Proof server - generates ZK proofs locally.
-  # Note: official midnightnetwork image uses its own versioning (4.0.0),
-  # which is compatible with the Ledger v7 / midnight-js 3.0.0 stack.
+  # Note: proof-server is still published under midnightnetwork/ (not midnightntwrk/)
+  # as of SDK 3.0.0. Uses its own versioning (4.0.0), compatible with Ledger v7.
   proof-server:
     image: midnightnetwork/proof-server:4.0.0
     ports:

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -11,11 +11,15 @@ export { CredentialProof } from "./proofs/credential-proof.js";
 // Types
 export type {
   Proof,
+  OfflineProof,
+  OnChainProof,
   ProofConfig,
   AgeProofInput,
   AgeProofOutput,
   CredentialProofInput,
   CredentialProofOutput,
 } from "./types.js";
+
+export { isOnChainProof } from "./types.js";
 
 export type { MidnightConfig, MidnightNetwork, ClientState } from "./midnight/client.js";

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -17,3 +17,5 @@ export type {
   CredentialProofInput,
   CredentialProofOutput,
 } from "./types.js";
+
+export type { MidnightConfig, MidnightNetwork, ClientState } from "./midnight/client.js";

--- a/sdk/src/midnight/client.ts
+++ b/sdk/src/midnight/client.ts
@@ -33,8 +33,8 @@ export interface MidnightConfig {
   nodeUrl?: string;
   /** Network type */
   network?: MidnightNetwork;
-  /** Skip network check (for testing) */
-  skipNetworkCheck?: boolean;
+  /** Force offline mode — network will not be checked; proofs use placeholders */
+  forceOffline?: boolean;
   /** Network check timeout in ms (default: 1000) */
   networkCheckTimeoutMs?: number;
   /** Path to compiled contract assets (managed/ directory) */
@@ -50,7 +50,7 @@ const DEFAULT_CONFIG: Required<MidnightConfig> = {
   indexerUrl: "http://localhost:8088",
   nodeUrl: "ws://localhost:9944",
   network: "standalone",
-  skipNetworkCheck: false,
+  forceOffline: false,
   networkCheckTimeoutMs: 1000,
   contractAssetsPath: "",
 };
@@ -98,7 +98,7 @@ export function createProviders(config: MidnightConfig = {}): MidnightProviders 
 export async function isNetworkAvailable(config: MidnightConfig = {}): Promise<boolean> {
   const mergedConfig = { ...DEFAULT_CONFIG, ...config };
 
-  if (mergedConfig.skipNetworkCheck) {
+  if (mergedConfig.forceOffline) {
     return false;
   }
 

--- a/sdk/src/midnight/client.ts
+++ b/sdk/src/midnight/client.ts
@@ -16,6 +16,14 @@ import {
 } from "@midnight-ntwrk/midnight-js-contracts";
 import type { FinalizedTxData } from "@midnight-ntwrk/midnight-js-types";
 
+/** Supported Midnight network targets. */
+export type MidnightNetwork =
+  | "standalone"
+  | "testnet"
+  | "preview"
+  | "preprod"
+  | "mainnet";
+
 export interface MidnightConfig {
   /** Proof server URL (default: http://localhost:6300) */
   proofServerUrl?: string;
@@ -24,7 +32,7 @@ export interface MidnightConfig {
   /** Node WebSocket URL (default: ws://localhost:9944) */
   nodeUrl?: string;
   /** Network type */
-  network?: "standalone" | "testnet";
+  network?: MidnightNetwork;
   /** Skip network check (for testing) */
   skipNetworkCheck?: boolean;
   /** Network check timeout in ms (default: 1000) */
@@ -225,7 +233,7 @@ export async function queryTransaction(
  */
 export interface ClientState {
   connected: boolean;
-  network: "standalone" | "testnet" | "mocked";
+  network: MidnightNetwork | "mocked";
   providers?: MidnightProviders;
   config?: MidnightConfig;
 }

--- a/sdk/src/proofs/age-verification.ts
+++ b/sdk/src/proofs/age-verification.ts
@@ -226,6 +226,12 @@ export class AgeVerification {
       return this.verifyMidnightProof(proof);
     }
 
+    // On mainnet, reject placeholder proofs in the verify path too —
+    // they should never be accepted in a production environment.
+    if (this.config.network === "mainnet") {
+      return false;
+    }
+
     // Placeholder proofs are trusted only in offline/test mode
     return true;
   }

--- a/sdk/src/proofs/age-verification.ts
+++ b/sdk/src/proofs/age-verification.ts
@@ -105,7 +105,15 @@ export class AgeVerification {
       return this.generateWithMidnight(birthDate, minAge, currentDate, input.requesterDid);
     }
 
-    // Fall back to placeholder proof
+    // On mainnet, never fall back to placeholder proofs — this is a security gap.
+    // Placeholder proofs are only acceptable for development/testing networks.
+    if (this.config.network === "mainnet") {
+      throw new Error(
+        "Midnight network unavailable. Placeholder proofs are disabled on mainnet for security."
+      );
+    }
+
+    // Fall back to placeholder proof (non-mainnet only)
     return this.generatePlaceholder(birthDate, minAge, currentDate, input.requesterDid);
   }
 

--- a/sdk/src/proofs/age-verification.ts
+++ b/sdk/src/proofs/age-verification.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Proof, ProofConfig, AgeProofInput } from "../types.js";
+import { isOnChainProof } from "../types.js";
 import {
   getClientState,
   initializeClient,
@@ -17,7 +18,8 @@ import {
   queryTransaction,
   type MidnightConfig,
 } from "../midnight/client.js";
-import { createAgeWitnesses, parseDateForCircuit } from "../midnight/witnesses.js";
+// TODO(#7): Re-import when full deployment flow is wired up
+// import { createAgeWitnesses, parseDateForCircuit } from "../midnight/witnesses.js";
 
 export class AgeVerification {
   private initialized = false;
@@ -82,6 +84,7 @@ export class AgeVerification {
 
     if (!birthDate || isNaN(birthDate.getTime())) {
       return {
+        verificationMethod: "offline",
         proof: "",
         publicSignals: { verified: false, error: "Invalid or missing birth date" },
         verificationKey: "",
@@ -120,67 +123,24 @@ export class AgeVerification {
   /**
    * Generate proof using real Midnight network.
    *
-   * Currently prepares circuit inputs and witnesses but returns a
-   * locally-computed result without deploying a contract or submitting
-   * a transaction. The returned proof will NOT contain txId,
-   * contractAddress, or blockHeight — verifyMidnightProof() will
-   * therefore reject it until full on-chain deployment is wired up.
-   *
-   * Target flow (see https://github.com/peteski22/pci-zkp/issues/7):
+   * Not yet implemented — requires full wallet + contract deployment flow.
+   * See https://github.com/peteski22/pci-zkp/issues/7 for the roadmap:
    * 1. Deploy a fresh ephemeral contract (privacy: no cross-verifier linkability)
    * 2. Set private state (birth date) via witnesses
    * 3. Call contract.callTx.verifyAge() — auto-generates ZK proof
    * 4. Extract txId, blockHeight, contractAddress from finalized tx
-   * 5. Return Proof with real on-chain metadata
+   * 5. Return OnChainProof with real on-chain metadata
    */
   private async generateWithMidnight(
-    birthDate: Date,
-    minAge: number,
-    currentDate: Date,
-    requesterDid?: string
+    _birthDate: Date,
+    _minAge: number,
+    _currentDate: Date,
+    _requesterDid?: string
   ): Promise<Proof> {
-    const clientState = getClientState();
-    if (!clientState.providers || !clientState.config) {
-      throw new Error("Midnight client not initialized");
-    }
-
-    // Prepare circuit inputs (used when full wallet + deployment flow is wired up).
-    // See https://github.com/peteski22/pci-zkp/issues/7 for the deployment roadmap.
-    const current = parseDateForCircuit(currentDate);
-    const witnesses = createAgeWitnesses(birthDate);
-    const circuitArgs = {
-      minAge: BigInt(minAge),
-      currentYear: current.year,
-      currentMonth: current.month,
-      currentDay: current.day,
-    };
-
-    void witnesses;
-    void circuitArgs;
-
-    // Calculate the expected result until full on-chain execution is wired up.
-    const verified = this.calculateAge(birthDate, currentDate) >= minAge;
-
-    const publicSignals: Record<string, unknown> = {
-      verified,
-      minAge,
-      network: "midnight",
-    };
-
-    if (requesterDid) {
-      publicSignals.requesterDid = requesterDid;
-    }
-
-    return {
-      proof: this.generateMidnightProofData(verified, minAge),
-      publicSignals,
-      verificationKey: "age_verification_vk_midnight",
-      circuitId: "age_verification",
-      timestamp: new Date(),
-      // txId, contractAddress, blockHeight will be populated when full
-      // wallet + deployment flow is wired up. Verification checks for
-      // these fields to distinguish on-chain proofs from pending ones.
-    };
+    throw new Error(
+      "On-chain proof generation requires full Midnight deployment (see issue #7). " +
+        "Use offline mode for now."
+    );
   }
 
   /**
@@ -208,6 +168,7 @@ export class AgeVerification {
     }
 
     return {
+      verificationMethod: "offline",
       proof: this.generatePlaceholderProofData(),
       publicSignals,
       verificationKey: "age_verification_vk_placeholder",
@@ -273,19 +234,25 @@ export class AgeVerification {
    * Verify a Midnight-generated proof via on-chain data
    *
    * Verification strategy (Midnight has no off-chain verification API):
-   * 1. Require txId and contractAddress (on-chain metadata)
+   * 1. Require on-chain proof (verificationMethod === "on-chain")
    * 2. Query the contract state from the indexer to read the `verified` field
    * 3. Confirm the transaction exists on-chain at the claimed block height
    *
-   * Proofs without txId/contractAddress are rejected — they lack the on-chain
-   * record needed for cryptographic verification.
+   * SECURITY NOTE: The indexer does not currently expose which contract a
+   * transaction targets, so we verify tx existence and contract state
+   * independently. This is acceptable because each contract is ephemeral
+   * (single-use, deployed per proof interaction). An attacker who deploys
+   * their own contract can only set `verified=true` on their own instance —
+   * the contractAddress in the proof binds to the specific instance.
+   * A future indexer API upgrade should allow binding txId → contractAddress.
+   *
+   * Offline proofs are rejected — they lack the on-chain record needed for
+   * cryptographic verification.
    */
   private async verifyMidnightProof(proof: Proof): Promise<boolean> {
     // Require on-chain metadata for verification
-    if (!proof.txId || !proof.contractAddress) {
-      // No on-chain metadata — cannot verify. This happens when proof generation
-      // used the Midnight network marker but didn't complete full deployment.
-      // Reject rather than blindly trusting.
+    if (!isOnChainProof(proof)) {
+      // Offline proof — cannot verify via on-chain data.
       return false;
     }
 
@@ -311,19 +278,14 @@ export class AgeVerification {
       return false;
     }
 
-    // 3. Confirm the transaction exists on-chain.
-    // Note: the indexer does not currently expose which contract a
-    // transaction targets, so we cannot verify tx-contract association.
-    // This is acceptable for now because each contract is ephemeral
-    // (single-use), but a future indexer API upgrade should allow
-    // binding the txId to the contractAddress.
+    // 3. Confirm the transaction exists on-chain (see SECURITY NOTE above).
     const txResult = await queryTransaction(indexerUrl, proof.txId);
     if (!txResult) {
       return false;
     }
 
-    // 4. If proof claims a specific block height, verify it matches.
-    if (proof.blockHeight !== undefined && txResult.blockHeight !== proof.blockHeight) {
+    // 4. Verify block height matches.
+    if (txResult.blockHeight !== proof.blockHeight) {
       return false;
     }
 
@@ -340,15 +302,6 @@ export class AgeVerification {
     ).toString("base64");
   }
 
-  private generateMidnightProofData(verified: boolean, minAge: number): string {
-    return Buffer.from(
-      JSON.stringify({
-        type: "age_verification",
-        version: "2.0",
-        network: "midnight",
-        verified,
-        minAge,
-      })
-    ).toString("base64");
-  }
+  // TODO(#7): generateMidnightProofData() removed — will be replaced by
+  // real on-chain proof extraction when full deployment flow is wired up.
 }

--- a/sdk/src/proofs/credential-proof.ts
+++ b/sdk/src/proofs/credential-proof.ts
@@ -82,11 +82,10 @@ export class CredentialProof {
     }
 
     // If proof has on-chain metadata, it needs indexer verification.
-    // Not yet implemented for credential proofs.
+    // Not yet implemented for credential proofs — reject rather than throw
+    // so callers can rely on the Promise<boolean> contract.
     if (isOnChainProof(proof)) {
-      throw new Error(
-        "On-chain verification for credential proofs is not yet implemented."
-      );
+      return false;
     }
 
     return true;

--- a/sdk/src/proofs/credential-proof.ts
+++ b/sdk/src/proofs/credential-proof.ts
@@ -8,6 +8,7 @@ import type {
   CredentialProofInput,
   CredentialProofOutput,
 } from "../types.js";
+import { isOnChainProof } from "../types.js";
 
 export class CredentialProof {
   constructor(private readonly _config: ProofConfig) {
@@ -35,6 +36,7 @@ export class CredentialProof {
 
     // TODO: Integrate with Midnight SDK for actual ZKP generation
     const proof: Proof = {
+      verificationMethod: "offline",
       proof: this.generatePlaceholderProof(),
       publicSignals: {
         valid,
@@ -79,10 +81,12 @@ export class CredentialProof {
       return false;
     }
 
-    // If proof has any on-chain metadata, it needs indexer verification.
-    // Not yet implemented for credential proofs, so treat as unverifiable.
-    if (proof.txId || proof.contractAddress) {
-      return false;
+    // If proof has on-chain metadata, it needs indexer verification.
+    // Not yet implemented for credential proofs.
+    if (isOnChainProof(proof)) {
+      throw new Error(
+        "On-chain verification for credential proofs is not yet implemented."
+      );
     }
 
     return true;

--- a/sdk/src/server.ts
+++ b/sdk/src/server.ts
@@ -7,6 +7,7 @@
 
 import { createServer, IncomingMessage, ServerResponse } from "node:http";
 import type { ProofConfig } from "./types.js";
+import type { MidnightConfig, MidnightNetwork } from "./midnight/client.js";
 import * as proofModules from "./proofs/index.js";
 
 const PORT = parseInt(process.env.PORT || "8084", 10);
@@ -19,10 +20,22 @@ interface ProofHandler {
 const proofHandlers: Record<string, ProofHandler> = {};
 
 /**
- * Load all proof handlers from the barrel export
+ * Load all proof handlers from the barrel export.
+ *
+ * Reads Midnight network configuration from environment variables and
+ * passes it through to each proof handler constructor so that handlers
+ * can connect to the correct node, indexer, and proof server.
  */
 function loadProofHandlers(): void {
-  const config: ProofConfig = { proverEndpoint: process.env.PROOF_SERVER_URL };
+  const network = (process.env.MIDNIGHT_NETWORK as MidnightNetwork | undefined) ?? undefined;
+
+  const config: ProofConfig & MidnightConfig = {
+    proverEndpoint: process.env.PROOF_SERVER_URL,
+    proofServerUrl: process.env.MIDNIGHT_PROOF_SERVER_URL ?? process.env.PROOF_SERVER_URL,
+    nodeUrl: process.env.MIDNIGHT_NODE_URL,
+    indexerUrl: process.env.MIDNIGHT_INDEXER_URL,
+    network,
+  };
 
   for (const [name, HandlerClass] of Object.entries(proofModules)) {
     if (typeof HandlerClass !== "function") continue;

--- a/sdk/src/server.ts
+++ b/sdk/src/server.ts
@@ -12,13 +12,13 @@ import * as proofModules from "./proofs/index.js";
 
 const PORT = parseInt(process.env.PORT || "8084", 10);
 
-const VALID_NETWORKS: readonly MidnightNetwork[] = [
+const VALID_NETWORKS = [
   "standalone",
   "testnet",
   "preview",
   "preprod",
   "mainnet",
-];
+] as const satisfies readonly MidnightNetwork[];
 
 function parseMidnightNetwork(raw: string | undefined): MidnightNetwork | undefined {
   if (!raw) return undefined;
@@ -46,11 +46,13 @@ function loadProofHandlers(): void {
   const network = parseMidnightNetwork(process.env.MIDNIGHT_NETWORK);
 
   const config: ProofConfig & MidnightConfig = {
-    proverEndpoint: process.env.PROOF_SERVER_URL,
-    proofServerUrl: process.env.MIDNIGHT_PROOF_SERVER_URL ?? process.env.PROOF_SERVER_URL,
-    nodeUrl: process.env.MIDNIGHT_NODE_URL,
-    indexerUrl: process.env.MIDNIGHT_INDEXER_URL,
-    network,
+    ...(process.env.PROOF_SERVER_URL && { proverEndpoint: process.env.PROOF_SERVER_URL }),
+    ...(( process.env.MIDNIGHT_PROOF_SERVER_URL || process.env.PROOF_SERVER_URL) && {
+      proofServerUrl: process.env.MIDNIGHT_PROOF_SERVER_URL ?? process.env.PROOF_SERVER_URL,
+    }),
+    ...(process.env.MIDNIGHT_NODE_URL && { nodeUrl: process.env.MIDNIGHT_NODE_URL }),
+    ...(process.env.MIDNIGHT_INDEXER_URL && { indexerUrl: process.env.MIDNIGHT_INDEXER_URL }),
+    ...(network && { network }),
   };
 
   for (const [name, HandlerClass] of Object.entries(proofModules)) {

--- a/sdk/src/server.ts
+++ b/sdk/src/server.ts
@@ -12,6 +12,22 @@ import * as proofModules from "./proofs/index.js";
 
 const PORT = parseInt(process.env.PORT || "8084", 10);
 
+const VALID_NETWORKS: readonly MidnightNetwork[] = [
+  "standalone",
+  "testnet",
+  "preview",
+  "preprod",
+  "mainnet",
+];
+
+function parseMidnightNetwork(raw: string | undefined): MidnightNetwork | undefined {
+  if (!raw) return undefined;
+  if ((VALID_NETWORKS as readonly string[]).includes(raw)) return raw as MidnightNetwork;
+  throw new Error(
+    `Invalid MIDNIGHT_NETWORK '${raw}'. Must be one of: ${VALID_NETWORKS.join(", ")}`
+  );
+}
+
 interface ProofHandler {
   generate(input: unknown): Promise<unknown>;
 }
@@ -27,7 +43,7 @@ const proofHandlers: Record<string, ProofHandler> = {};
  * can connect to the correct node, indexer, and proof server.
  */
 function loadProofHandlers(): void {
-  const network = (process.env.MIDNIGHT_NETWORK as MidnightNetwork | undefined) ?? undefined;
+  const network = parseMidnightNetwork(process.env.MIDNIGHT_NETWORK);
 
   const config: ProofConfig & MidnightConfig = {
     proverEndpoint: process.env.PROOF_SERVER_URL,

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -2,7 +2,7 @@
  * Type definitions for PCI ZKP SDK
  */
 
-export interface Proof {
+interface ProofBase {
   /** Serialized proof data */
   proof: string;
   /** Public signals/outputs */
@@ -13,12 +13,29 @@ export interface Proof {
   circuitId: string;
   /** Generation timestamp */
   timestamp: Date;
-  /** Midnight transaction ID (present when proof was submitted on-chain) */
-  txId?: string;
+}
+
+/** Proof generated offline or via placeholder — no on-chain metadata. */
+export interface OfflineProof extends ProofBase {
+  verificationMethod: "offline";
+}
+
+/** Proof verified on-chain — contains transaction and contract metadata. */
+export interface OnChainProof extends ProofBase {
+  verificationMethod: "on-chain";
+  /** Midnight transaction ID */
+  txId: string;
   /** Contract address for this specific proof interaction */
-  contractAddress?: string;
+  contractAddress: string;
   /** Block height where proof was confirmed */
-  blockHeight?: number;
+  blockHeight: number;
+}
+
+export type Proof = OfflineProof | OnChainProof;
+
+/** Type guard: is this an on-chain proof? */
+export function isOnChainProof(p: Proof): p is OnChainProof {
+  return p.verificationMethod === "on-chain";
 }
 
 export interface ProofConfig {

--- a/tests/integration/midnight-network.test.ts
+++ b/tests/integration/midnight-network.test.ts
@@ -77,7 +77,7 @@ describe("Midnight Network Integration", () => {
   });
 
   describe("Age Verification with Network", () => {
-    it("should generate proof using Midnight network", async () => {
+    it("should throw when generating proof with Midnight (not yet implemented)", async () => {
       if (!isNetworkUp) {
         console.log("Skipping: Network not available");
         return;
@@ -88,62 +88,15 @@ describe("Midnight Network Integration", () => {
         indexerUrl: INDEXER_URL,
       });
 
-      const proof = await verifier.generate({
-        birthDate: new Date("1990-01-15"),
-        minAge: 18,
-      });
-
-      expect(proof.circuitId).toBe("age_verification");
-      expect(proof.publicSignals.verified).toBe(true);
-      expect(proof.publicSignals.minAge).toBe(18);
-      expect(proof.publicSignals.network).toBe("midnight");
-    });
-
-    it("should verify proof generated with Midnight", async () => {
-      if (!isNetworkUp) {
-        console.log("Skipping: Network not available");
-        return;
-      }
-
-      const verifier = new AgeVerification({
-        proofServerUrl: PROOF_SERVER_URL,
-        indexerUrl: INDEXER_URL,
-      });
-
-      const proof = await verifier.generate({
-        birthDate: new Date("1990-01-15"),
-        minAge: 21,
-      });
-
-      // Until full wallet + deployment flow is wired, Midnight proofs
-      // lack on-chain metadata (txId/contractAddress), so verify() will
-      // reject them. This is the correct security behavior.
-      const isValid = await verifier.verify(proof);
-      // Proofs without on-chain metadata are rejected in Midnight mode
-      expect(isValid).toBe(false);
-    });
-
-    it("should correctly reject underage proof", async () => {
-      if (!isNetworkUp) {
-        console.log("Skipping: Network not available");
-        return;
-      }
-
-      const verifier = new AgeVerification({
-        proofServerUrl: PROOF_SERVER_URL,
-        indexerUrl: INDEXER_URL,
-      });
-
-      // Create a birth date that will always be under 18 (10 years ago)
-      const now = new Date();
-      const underageBirthDate = new Date(now.getFullYear() - 10, 0, 15);
-
-      const proof = await verifier.generate({
-        birthDate: underageBirthDate,
-        minAge: 18,
-      });
-
-      expect(proof.publicSignals.verified).toBe(false);
+      // On-chain proof generation is not yet implemented (see issue #7).
+      // When the network is available, generate() should throw rather than
+      // returning a proof that cannot be verified.
+      await expect(
+        verifier.generate({
+          birthDate: new Date("1990-01-15"),
+          minAge: 18,
+        })
+      ).rejects.toThrow("issue #7");
     });
   });
 
@@ -162,14 +115,13 @@ describe("Midnight Network Integration", () => {
       expect(proof.circuitId).toBe("age_verification");
       expect(proof.publicSignals.verified).toBe(true);
       expect(proof.publicSignals.network).toBe("mocked");
-      // Placeholder proofs don't have on-chain metadata
-      expect(proof.txId).toBeUndefined();
-      expect(proof.contractAddress).toBeUndefined();
+      // Placeholder proofs are offline
+      expect(proof.verificationMethod).toBe("offline");
     });
 
     it("should skip network check when configured", async () => {
       const verifier = new AgeVerification({
-        skipNetworkCheck: true,
+        forceOffline: true,
       });
 
       const proof = await verifier.generate({
@@ -182,7 +134,7 @@ describe("Midnight Network Integration", () => {
   });
 
   describe("Ephemeral Contract Privacy", () => {
-    it("should generate different proofs for same input (no state sharing)", async () => {
+    it("should throw for both verifiers (on-chain not yet implemented)", async () => {
       if (!isNetworkUp) {
         console.log("Skipping: Network not available");
         return;
@@ -198,25 +150,15 @@ describe("Midnight Network Integration", () => {
         indexerUrl: INDEXER_URL,
       });
 
-      const proof1 = await verifier1.generate({
-        birthDate: new Date("1990-01-15"),
-        minAge: 18,
-      });
+      // Both should throw — on-chain generation not yet implemented.
+      // TODO(#7): Once full deployment is wired, assert different contractAddresses.
+      await expect(
+        verifier1.generate({ birthDate: new Date("1990-01-15"), minAge: 18 })
+      ).rejects.toThrow("issue #7");
 
-      const proof2 = await verifier2.generate({
-        birthDate: new Date("1990-01-15"),
-        minAge: 18,
-      });
-
-      // Both should be valid
-      expect(proof1.publicSignals.verified).toBe(true);
-      expect(proof2.publicSignals.verified).toBe(true);
-
-      // Verify they are structurally independent proof instances.
-      // TODO: Once full deployment is wired, assert different contractAddresses here.
-      expect(proof1.proof).toBeDefined();
-      expect(proof2.proof).toBeDefined();
-      expect(proof1.verificationKey).toBe(proof2.verificationKey);
+      await expect(
+        verifier2.generate({ birthDate: new Date("1990-01-15"), minAge: 18 })
+      ).rejects.toThrow("issue #7");
     });
   });
 });

--- a/tests/integration/midnight-network.test.ts
+++ b/tests/integration/midnight-network.test.ts
@@ -14,6 +14,9 @@ import { isNetworkAvailable, initializeClient, getClientState } from "../../sdk/
 const PROOF_SERVER_URL = process.env.MIDNIGHT_PROOF_SERVER_URL || "http://localhost:6300";
 const INDEXER_URL = process.env.MIDNIGHT_INDEXER_URL || "http://localhost:8088";
 
+/** Shared matcher for the "not yet implemented" error thrown by on-chain proof generation. */
+const NOT_IMPLEMENTED_RE = /issue #7/;
+
 describe("Midnight Network Integration", () => {
   let isNetworkUp = false;
 
@@ -96,7 +99,7 @@ describe("Midnight Network Integration", () => {
           birthDate: new Date("1990-01-15"),
           minAge: 18,
         })
-      ).rejects.toThrow("issue #7");
+      ).rejects.toThrow(NOT_IMPLEMENTED_RE);
     });
   });
 
@@ -154,11 +157,11 @@ describe("Midnight Network Integration", () => {
       // TODO(#7): Once full deployment is wired, assert different contractAddresses.
       await expect(
         verifier1.generate({ birthDate: new Date("1990-01-15"), minAge: 18 })
-      ).rejects.toThrow("issue #7");
+      ).rejects.toThrow(NOT_IMPLEMENTED_RE);
 
       await expect(
         verifier2.generate({ birthDate: new Date("1990-01-15"), minAge: 18 })
-      ).rejects.toThrow("issue #7");
+      ).rejects.toThrow(NOT_IMPLEMENTED_RE);
     });
   });
 });

--- a/tests/proofs.test.ts
+++ b/tests/proofs.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ProofGenerator } from "../sdk/src/proofs/generator.js";
 import { AgeVerification } from "../sdk/src/proofs/age-verification.js";
 import type { Proof } from "../sdk/src/types.js";
+import { isOnChainProof } from "../sdk/src/types.js";
 import * as client from "../sdk/src/midnight/client.js";
 
 describe("ProofGenerator", () => {
@@ -114,6 +115,7 @@ describe("ProofGenerator", () => {
 
     it("should reject credential proof with empty credentialType", async () => {
       const proof: Proof = {
+        verificationMethod: "offline",
         proof: "dGVzdA==",
         publicSignals: {
           valid: true,
@@ -131,6 +133,7 @@ describe("ProofGenerator", () => {
 
     it("should reject credential proof with empty issuerPublicKey", async () => {
       const proof: Proof = {
+        verificationMethod: "offline",
         proof: "dGVzdA==",
         publicSignals: {
           valid: true,
@@ -192,9 +195,10 @@ describe("AgeVerification", () => {
   });
 });
 
-describe("Proof type with on-chain fields", () => {
-  it("should accept proof with txId and contractAddress", () => {
+describe("Proof discriminated union", () => {
+  it("should accept on-chain proof with all required fields", () => {
     const proof: Proof = {
+      verificationMethod: "on-chain",
       proof: "dGVzdA==",
       publicSignals: { verified: true, minAge: 18 },
       verificationKey: "age_verification_vk_midnight",
@@ -205,13 +209,17 @@ describe("Proof type with on-chain fields", () => {
       blockHeight: 42,
     };
 
-    expect(proof.txId).toBe("abc123def456");
-    expect(proof.contractAddress).toBe("0x1234567890abcdef");
-    expect(proof.blockHeight).toBe(42);
+    expect(isOnChainProof(proof)).toBe(true);
+    if (isOnChainProof(proof)) {
+      expect(proof.txId).toBe("abc123def456");
+      expect(proof.contractAddress).toBe("0x1234567890abcdef");
+      expect(proof.blockHeight).toBe(42);
+    }
   });
 
-  it("should accept proof without on-chain fields (placeholder)", () => {
+  it("should accept offline proof without on-chain fields", () => {
     const proof: Proof = {
+      verificationMethod: "offline",
       proof: "dGVzdA==",
       publicSignals: { verified: true, minAge: 18 },
       verificationKey: "age_verification_vk_placeholder",
@@ -219,16 +227,14 @@ describe("Proof type with on-chain fields", () => {
       timestamp: new Date(),
     };
 
-    expect(proof.txId).toBeUndefined();
-    expect(proof.contractAddress).toBeUndefined();
-    expect(proof.blockHeight).toBeUndefined();
+    expect(isOnChainProof(proof)).toBe(false);
   });
 });
 
 describe("AgeVerification - Midnight mode verification", () => {
   it("should accept placeholder proofs in offline mode", async () => {
     const verifier = new AgeVerification({
-      skipNetworkCheck: true, // Forces offline — placeholder proofs are trusted
+      forceOffline: true, // Forces offline mode — placeholder proofs are trusted
     });
 
     // Generate an offline proof
@@ -247,6 +253,7 @@ describe("AgeVerification - Midnight mode verification", () => {
     const verifier = new AgeVerification({});
 
     const malformedProof: Proof = {
+      verificationMethod: "offline",
       proof: "dGVzdA==",
       publicSignals: { verified: "not-a-boolean", minAge: "not-a-number" },
       verificationKey: "test_vk",
@@ -303,6 +310,7 @@ describe("AgeVerification - verifyMidnightProof branches", () => {
   // Helper: build a valid on-chain proof for testing.
   function makeOnChainProof(overrides: Partial<Proof> = {}): Proof {
     return {
+      verificationMethod: "on-chain",
       proof: "dGVzdA==",
       publicSignals: { verified: true, minAge: 18 },
       verificationKey: "age_verification_vk_midnight",
@@ -312,7 +320,7 @@ describe("AgeVerification - verifyMidnightProof branches", () => {
       contractAddress: "0xcontract",
       blockHeight: 10,
       ...overrides,
-    };
+    } as Proof;
   }
 
   // Force the verifier into Midnight mode via mocks.
@@ -329,21 +337,18 @@ describe("AgeVerification - verifyMidnightProof branches", () => {
     vi.restoreAllMocks();
   });
 
-  it("should reject proof without txId in Midnight mode", async () => {
+  it("should reject offline proof in Midnight mode", async () => {
     mockMidnightMode();
 
     const verifier = new AgeVerification({});
-    const proof = makeOnChainProof({ txId: undefined });
-
-    const isValid = await verifier.verify(proof);
-    expect(isValid).toBe(false);
-  });
-
-  it("should reject proof without contractAddress in Midnight mode", async () => {
-    mockMidnightMode();
-
-    const verifier = new AgeVerification({});
-    const proof = makeOnChainProof({ contractAddress: undefined });
+    const proof: Proof = {
+      verificationMethod: "offline",
+      proof: "dGVzdA==",
+      publicSignals: { verified: true, minAge: 18 },
+      verificationKey: "age_verification_vk_midnight",
+      circuitId: "age_verification",
+      timestamp: new Date(),
+    };
 
     const isValid = await verifier.verify(proof);
     expect(isValid).toBe(false);
@@ -433,17 +438,6 @@ describe("AgeVerification - verifyMidnightProof branches", () => {
     expect(isValid).toBe(true);
   });
 
-  it("should accept proof when blockHeight is not specified (skip height check)", async () => {
-    mockMidnightMode();
-    vi.spyOn(client, "queryContractState").mockResolvedValue({ verified: true });
-    vi.spyOn(client, "queryTransaction").mockResolvedValue({ blockHeight: 42 });
-
-    const verifier = new AgeVerification({});
-    const proof = makeOnChainProof({ blockHeight: undefined });
-
-    const isValid = await verifier.verify(proof);
-    expect(isValid).toBe(true);
-  });
 });
 
 describe("AgeVerification - mainnet fallback protection", () => {
@@ -454,7 +448,7 @@ describe("AgeVerification - mainnet fallback protection", () => {
   it("should throw error on mainnet when network is unavailable instead of falling back", async () => {
     const verifier = new AgeVerification({
       network: "mainnet",
-      skipNetworkCheck: true, // Forces offline
+      forceOffline: true, // Forces offline
     });
 
     await expect(
@@ -468,7 +462,7 @@ describe("AgeVerification - mainnet fallback protection", () => {
   it("should allow placeholder fallback on standalone network", async () => {
     const verifier = new AgeVerification({
       network: "standalone",
-      skipNetworkCheck: true,
+      forceOffline: true,
     });
 
     const proof = await verifier.generate({
@@ -483,7 +477,7 @@ describe("AgeVerification - mainnet fallback protection", () => {
   it("should allow placeholder fallback on preview network", async () => {
     const verifier = new AgeVerification({
       network: "preview",
-      skipNetworkCheck: true,
+      forceOffline: true,
     });
 
     const proof = await verifier.generate({
@@ -497,7 +491,7 @@ describe("AgeVerification - mainnet fallback protection", () => {
   it("should allow placeholder fallback on preprod network", async () => {
     const verifier = new AgeVerification({
       network: "preprod",
-      skipNetworkCheck: true,
+      forceOffline: true,
     });
 
     const proof = await verifier.generate({

--- a/tests/proofs.test.ts
+++ b/tests/proofs.test.ts
@@ -445,3 +445,82 @@ describe("AgeVerification - verifyMidnightProof branches", () => {
     expect(isValid).toBe(true);
   });
 });
+
+describe("AgeVerification - mainnet fallback protection", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should throw error on mainnet when network is unavailable instead of falling back", async () => {
+    const verifier = new AgeVerification({
+      network: "mainnet",
+      skipNetworkCheck: true, // Forces offline
+    });
+
+    await expect(
+      verifier.generate({
+        birthDate: new Date("1990-01-15"),
+        minAge: 18,
+      })
+    ).rejects.toThrow("Placeholder proofs are disabled on mainnet");
+  });
+
+  it("should allow placeholder fallback on standalone network", async () => {
+    const verifier = new AgeVerification({
+      network: "standalone",
+      skipNetworkCheck: true,
+    });
+
+    const proof = await verifier.generate({
+      birthDate: new Date("1990-01-15"),
+      minAge: 18,
+    });
+
+    expect(proof.publicSignals.network).toBe("mocked");
+    expect(proof.publicSignals.verified).toBe(true);
+  });
+
+  it("should allow placeholder fallback on preview network", async () => {
+    const verifier = new AgeVerification({
+      network: "preview",
+      skipNetworkCheck: true,
+    });
+
+    const proof = await verifier.generate({
+      birthDate: new Date("1990-01-15"),
+      minAge: 18,
+    });
+
+    expect(proof.publicSignals.network).toBe("mocked");
+  });
+
+  it("should allow placeholder fallback on preprod network", async () => {
+    const verifier = new AgeVerification({
+      network: "preprod",
+      skipNetworkCheck: true,
+    });
+
+    const proof = await verifier.generate({
+      birthDate: new Date("1990-01-15"),
+      minAge: 18,
+    });
+
+    expect(proof.publicSignals.network).toBe("mocked");
+  });
+});
+
+describe("MidnightNetwork type union", () => {
+  it("should accept all valid network types in MidnightConfig", () => {
+    const networks: Array<client.ClientState["network"]> = [
+      "standalone",
+      "testnet",
+      "preview",
+      "preprod",
+      "mainnet",
+      "mocked",
+    ];
+
+    // Type-level check: all values are assignable to the union
+    expect(networks).toHaveLength(6);
+  });
+});

--- a/tests/proofs.test.ts
+++ b/tests/proofs.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { ProofGenerator } from "../sdk/src/proofs/generator.js";
 import { AgeVerification } from "../sdk/src/proofs/age-verification.js";
-import type { Proof } from "../sdk/src/types.js";
+import type { Proof, OnChainProof } from "../sdk/src/types.js";
 import { isOnChainProof } from "../sdk/src/types.js";
 import * as client from "../sdk/src/midnight/client.js";
 
@@ -308,9 +308,9 @@ describe("AgeVerification - Midnight mode verification", () => {
 
 describe("AgeVerification - verifyMidnightProof branches", () => {
   // Helper: build a valid on-chain proof for testing.
-  function makeOnChainProof(overrides: Partial<Proof> = {}): Proof {
+  function makeOnChainProof(overrides: Partial<OnChainProof> = {}): Proof {
     return {
-      verificationMethod: "on-chain",
+      verificationMethod: "on-chain" as const,
       proof: "dGVzdA==",
       publicSignals: { verified: true, minAge: 18 },
       verificationKey: "age_verification_vk_midnight",
@@ -320,7 +320,7 @@ describe("AgeVerification - verifyMidnightProof branches", () => {
       contractAddress: "0xcontract",
       blockHeight: 10,
       ...overrides,
-    } as Proof;
+    };
   }
 
   // Force the verifier into Midnight mode via mocks.


### PR DESCRIPTION
## Summary

- Extends `MidnightNetwork` type to support all current network targets (standalone, testnet, preview, preprod, mainnet)
- Wires Midnight environment variables through `server.ts` so proof handlers connect to the correct infrastructure
- Disables placeholder proof fallback on mainnet to prevent insecure mocked proofs in production
- Updates README for current toolchain versions (Node.js 22+, Compact 0.28.0, v3 indexer API)

## Changes

### SDK Types (`client.ts`)
- `MidnightNetwork` expanded: `"standalone" | "testnet" | "preview" | "preprod" | "mainnet"`
- `ClientState.network` updated to include all network types
- Both types exported from SDK barrel (`index.ts`)

### Mainnet Security (`age-verification.ts`)
- When `network === "mainnet"` and Midnight is unavailable, throws error instead of falling back to placeholder proof
- Placeholder proofs remain available on all other networks for development/testing

### Server Configuration (`server.ts`)
- Reads `MIDNIGHT_NETWORK`, `MIDNIGHT_NODE_URL`, `MIDNIGHT_INDEXER_URL`, `MIDNIGHT_PROOF_SERVER_URL` from environment
- Passes config through to proof handler constructors

### Tests
- 44 tests passing (35 unit + 9 integration skipped correctly)
- New tests: mainnet fallback protection, standalone/preview/preprod placeholder allowed, network type union

## Dependencies

- Works with pci-infra PR (peteski22/pci-infra#2) which wires the same env vars through Docker Compose

## Test plan

- [x] `pnpm lint` passes
- [x] 44 tests pass (unit + integration skip when network unavailable)
- [ ] Manual test against preprod network with proof server 7.0.0

Refs #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Node.js prerequisite updated to 22+
  * Compact references updated to 0.28.0
  * GraphQL endpoint path updated to /api/v3/graphql

* **New Features**
  * Network support extended to testnet, preview, preprod and mainnet
  * Proofs now include a verificationMethod to distinguish offline vs on‑chain
  * Added forceOffline option to enforce offline verification mode

* **Bug Fixes**
  * Placeholder/offline proofs blocked on mainnet when network unavailable
<!-- end of auto-generated comment: release notes by coderabbit.ai -->