### PR TITLE
chore: ignore Claude local config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ npm-debug.log*
 # Lock files (using pnpm)
 package-lock.json
 yarn.lock
+
+# Claude Code local config (do not commit)
+.claude/
+AGENTS.md
+CLAUDE.md


### PR DESCRIPTION
## Summary

Add `.claude/`, `AGENTS.md`, and `CLAUDE.md` to `.gitignore` so Claude Code's local per-repo config never gets accidentally committed.

## Rationale

These files are local editor/agent config that vary per developer. They must not be tracked. This PR is one of a batch of near-identical PRs across the PCI repos to close the footgun uniformly.

## Test plan

- [ ] `git status` in a fresh clone no longer shows the three files
- [ ] Existing local copies of the files are untouched