### PR TITLE
docs: add Midnight Network attribution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Layer 4: Zero-knowledge proofs via Midnight for Personal Context Infrastructure.
 
+This project is built on the Midnight Network.
+
 ## Overview
 
 PCI ZKP provides:


### PR DESCRIPTION
Adds the exact attribution sentence for projects running directly on Midnight ("This project is built on the Midnight Network.") near the top of the README, as requested for the Midnight ecosystem map / Electric Capital developer report (peteski22/pci-infra#3). The `midnightntwrk` and `compact` repo topics have been added separately via repo settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to state that the project is built on the Midnight Network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->